### PR TITLE
Add support for dynamicallly loading profiles from configmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,15 @@ Similarly to what we are used to from cloud providers and platforms like Open St
 
 # How to Use
 
+## ConfigMap Method
+
 The method `load_profiles` can download a given ConfigMap from OpenShift/Kubernetes and extract the configuration from `data` section. This allows for dynamic changes to how (with what environment variables) singleuser servers are deployed - by updating the configuration in the ConfigMap, changes can be automatically pulled on singleuser server (re)start.
 
+By default, the `load_profiles` method attempts to read profile data from a ConfigMap named "jupyter-singleuser-profiles". In addition, it will also search for any ConfigMap with a label that matches "jupyterhub=singleuser-profiles" and load profile data from a key therein named "jupyterhub-singleuser-profiles.yaml". This allows for dynamic customization of the JupyterHub deployment. These ConfigMaps will be loaded alphabetically, where configuration in later ConfigMaps will override earlier ones.
+
 This approach requires `c.KubeSpawner.modify_pod_hook` option to point to a function similar to [this](https://github.com/AICoE/jupyterhub-ocp-oauth/blob/master/.jupyter/jupyterhub_config.py#L192) - it simply calls out to `SingleuserProfiles.apply_pod_profile` which takes a pod and updates its configuration based on the profile and returns new pod manifest.
+
+## Static File Method
 
 The profiles library can also read configuration from file - although this feature is more for testing purposes (to not require OpenShift/Kubernetes for developlment), it is possible to use file as a source of configuration in production.
 

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -54,6 +54,8 @@ class SingleuserProfiles(object):
       return config_maps_list
     for cm in config_maps.items:
       config_maps_list.append(cm.metadata.name)
+
+    _LOGGER.info("Found these additional Config Maps: %s" % config_maps_list)
     return config_maps_list
 
   def read_config_map(self, config_map_name, key_name="profiles"):
@@ -99,10 +101,10 @@ class SingleuserProfiles(object):
     self.profiles = []
     self.sizes = []
     if self.api_client:
-      profiles_config_maps = ['secret_name']
+      profiles_config_maps = [secret_name]
       profiles_config_maps.extend(sorted(self.get_config_maps_matching_label()))
       for cm_name in profiles_config_maps:
-        config_map_yaml = self.read_config_map(secret_name, key_name)
+        config_map_yaml = self.read_config_map(cm_name, key_name)
         if config_map_yaml:
           self.sizes.extend(config_map_yaml.get("sizes", [self.empty_profile()]))
           self.profiles.extend(config_map_yaml.get("profiles", [self.empty_profile()]))

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -44,6 +44,18 @@ class SingleuserProfiles(object):
     else:
       self._gpu_mode = None
 
+  def get_config_maps_matching_label(self, target_label='jupyterhub=singleuser-profiles'):
+    config_maps_list = []
+    try:
+      config_maps = self.api_client.list_namespaced_config_map(self.namespace, label_selector=target_label)
+    except ApiException as e:
+      if e.status != 404:
+        _LOGGER.error(e)
+      return config_maps_list
+    for cm in config_maps.items:
+      config_maps_list.append(cm.metadata.name)
+    return config_maps_list
+
   def read_config_map(self, config_map_name, key_name="profiles"):
     try:
       config_map = self.api_client.read_namespaced_config_map(config_map_name, self.namespace)
@@ -87,12 +99,15 @@ class SingleuserProfiles(object):
     self.profiles = []
     self.sizes = []
     if self.api_client:
-      config_map_yaml = self.read_config_map(secret_name, key_name)
-      if config_map_yaml:
-        self.sizes.extend(config_map_yaml.get("sizes", [self.empty_profile()]))
-        self.profiles.extend(config_map_yaml.get("profiles", [self.empty_profile()]))
-      else:
-        _LOGGER.error("Could not find config map %s" % config_map_name)
+      profiles_config_maps = ['secret_name']
+      profiles_config_maps.extend(sorted(self.get_config_maps_matching_label()))
+      for cm_name in profiles_config_maps:
+        config_map_yaml = self.read_config_map(secret_name, key_name)
+        if config_map_yaml:
+          self.sizes.extend(config_map_yaml.get("sizes", [self.empty_profile()]))
+          self.profiles.extend(config_map_yaml.get("profiles", [self.empty_profile()]))
+        else:
+          _LOGGER.error("Could not find config map %s" % config_map_name)
       if len(self.profiles) == 0:
         self.profiles.append(self.empty_profile())
       if username:


### PR DESCRIPTION
This adds support to the profiles code to dynamically identify any
config maps matching a target label and load profile data from matched
profiles.

Profiles will be processed alphabetically by name, providing for a level
of determinism on how the final resulting profile will be constructed.