### PR TITLE
Allow customization of notebook node affinity and tolerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,32 @@ This library helps to manage and configure singleuser JupyterHub servers deploye
 
 # Configuration
 
-```
-profiles:
+``` profiles:
   - name: globals
     env:
       THIS_IS_GLOBAL: "This will appear in all singleuser pods"
     resources:
       mem_limit: 1Gi
       cpu_limit: 500m
+  - name: Special Nodes
+    users:
+    - acorvin
+    # Set OpenShift node tolerations for a notebook pod. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more information.
+    node_tolerations:
+      - key: some_node_label
+        operator: Equal
+        value: label_target_value
+        effect: NoSchedule
+    # Set OpenShift node affinity for a notebook pod. See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ for more information.
+    node_affinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: some_node_label
+              operator: In
+              values:
+              - label_target_value_1
+              - label_target_value_2
   - name: Thoth Notebooks
     images:
     - 's2i-thoth-notebook:3.6'
@@ -59,6 +77,8 @@ sizes:
 * **images** is a list of image names (as used by `singleuser_image_spec` option in KubeSpawner)
 * **users** is a list of users allowed to use this profile, to ignore user filtering, specify `"*"` as a user name, or completely omit the `users` section
 * **env** is an object containing environment variables to be set for a singleuser server. *Keep in mind that all the values need to be strings - i.e. have quotes numbers!*
+* **node_tolerations** is a list of OpenShift node tolerations to be applied to the singleuser pod. See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more information.
+* **node_affinity** is an object containing node affinity definitions to be applied to the singleuser pod. See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ for more information.
 * **resources** is an object containing memory and cpu limits (which are then applied to the singleuser pod)
 * **services** is an object of objects describing services which should be run with the Jupyter Single User Server. See details below
 

--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -195,6 +195,8 @@ class SingleuserProfiles(object):
       "users": [],
       "images": [],
       "env": {},
+      "node_tolerations": [],
+      "node_affinity": {},
       "resources": {
         "mem_limit": None,
         "cpu_limit": None
@@ -210,6 +212,8 @@ class SingleuserProfiles(object):
     profile1["env"] = {**profile1.get('env', {}), **profile2.get('env', {})}
     profile1["resources"] = {**profile1.get('resources', {}), **profile2.get('resources', {})}
     profile1["services"] = {**profile1.get('services', {}), **profile2.get('services', {})}
+    profile1["node_tolerations"] = profile1.get("node_tolerations", []) + profile2.get("node_tolerations", [])
+    profile1["node_affinity"] = {**profile1.get('node_affinity', {}), **profile2.get('node_affinity', {})}
     return profile1
 
   @classmethod
@@ -232,6 +236,14 @@ class SingleuserProfiles(object):
       if profile['resources'].get('cpu_limit'):
         _LOGGER.info("Setting a cpu limit for %s in %s to %s" % (spawner.user.name, spawner.singleuser_image_spec, profile['resources']['cpu_limit']))
         pod.spec.containers[0].resources.limits['cpu'] = profile['resources']['cpu_limit']
+
+    if profile.get('node_tolerations'):
+        pod.spec.tolerations = profile.get('node_tolerations')
+
+    if profile.get('node_affinity'):
+        if not pod.spec.affinity:
+            pod.spec.affinity = {}
+        pod.spec.affinity['nodeAffinity'] = profile.get('node_affinity')
 
     for c in pod.spec.containers:
       update = False


### PR DESCRIPTION
This will allow users to customize the node tolerations and node
affinity settings for individual notebook pods by adding a
"node_tolerations" or "node_affinity" section to the singleuser
profiles.