### PR TITLE
Escape user name to prevent OpenShift rejecting invalid names

### DIFF
--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -258,7 +258,7 @@ class SingleuserProfiles(object):
   def apply_pod_profile(self, spawner, pod, profile):
     api_client = kubernetes.client.ApiClient()
 
-    pod.metadata.labels['jupyterhub.opendatahub.io/user'] = spawner.user.name
+    pod.metadata.labels['jupyterhub.opendatahub.io/user'] = escape(spawner.user.name)
 
     profile_environment = profile.get('env')
 

--- a/jupyterhub_singleuser_profiles/utils.py
+++ b/jupyterhub_singleuser_profiles/utils.py
@@ -1,6 +1,9 @@
-import re
+import escapism
+import string
 
-#TODO use proper escaping
 def escape(text):
-  import re
-  return re.sub("[^a-zA-Z0-9]+", "-", text)
+  # Make sure text match the restrictions for DNS labels
+  # Note: '-' is not in safe_chars, as it is being used as escape character
+  safe_chars = set(string.ascii_lowercase + string.digits)
+
+  return escapism.escape(text, safe=safe_chars, escape_char='-').lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML
 requests
 jsonpath-rw
 jinja2
+escapism


### PR DESCRIPTION
Make sure we espace all the necessary occurrences of  `username` and change the pattern for escaping to match that of Kubespawner